### PR TITLE
ci: Specify action versions as existing tags

### DIFF
--- a/.github/actions/cmake-project-setup/action.yaml
+++ b/.github/actions/cmake-project-setup/action.yaml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Install CMake
-      uses: lukka/get-cmake@latest
+      uses: lukka/get-cmake@v3.30.5
     - name: Setup anew (or from cache) vcpkg (and does not build any package)
       uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
     - name: Prepare CMakeUserPresets.json

--- a/.github/workflows/build-test-run.yaml
+++ b/.github/workflows/build-test-run.yaml
@@ -5,6 +5,8 @@ on:
       - "**.cpp"
       - "**.hpp"
       - "**/CMakeLists.txt"
+      - ".github/actions/cmake-project-setup/**"
+      - ".github/workflows/build-test-run.yaml"
       - ".github/CMakeUserPresets.json"
       - "aoc/**/input-*.txt"
       - "vcpkg-configuration.json"

--- a/.github/workflows/build-test-run.yaml
+++ b/.github/workflows/build-test-run.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup CMake project
         uses: ./.github/actions/cmake-project-setup
       - name: Run CMake workflow
-        uses: lukka/run-cmake@v10
+        uses: lukka/run-cmake@v10.7
         with:
           workflowPreset: "${{matrix.workflowPreset}}"
       - name: Run aoc

--- a/.github/workflows/check-clang-format.yaml
+++ b/.github/workflows/check-clang-format.yaml
@@ -5,6 +5,7 @@ on:
       - "**.cpp"
       - "**.hpp"
       - ".clang-format"
+      - ".github/workflows/check-clang-format.yaml"
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/check-clang-format.yaml
+++ b/.github/workflows/check-clang-format.yaml
@@ -16,6 +16,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@v2.0.0
       - name: Check with clang-format
         run: task check:clang-format

--- a/.github/workflows/check-clang-tidy.yaml
+++ b/.github/workflows/check-clang-tidy.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup CMake project
         uses: ./.github/actions/cmake-project-setup
       - name: Configure CMake project
-        uses: lukka/run-cmake@v10
+        uses: lukka/run-cmake@v10.7
         with:
           configurePreset: "${{matrix.configurePreset}}"
       - name: Run clang-tidy

--- a/.github/workflows/check-clang-tidy.yaml
+++ b/.github/workflows/check-clang-tidy.yaml
@@ -6,6 +6,8 @@ on:
       - "**.hpp"
       - "**/CMakeLists.txt"
       - ".clang-tidy"
+      - ".github/actions/cmake-project-setup/**"
+      - ".github/workflows/check-clang-tidy.yaml"
       - ".github/CMakeUserPresets.json"
       - "vcpkg-configuration.json"
       - "vcpkg.json"

--- a/.github/workflows/check-renovate-config.yaml
+++ b/.github/workflows/check-renovate-config.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - ".github/renovate.json5"
+      - ".github/workflows/check-renovate-config.yaml"
   workflow_call:
   workflow_dispatch:
 


### PR DESCRIPTION
Specify one release older than newest to trigger mend to update it. This should ensure that they actually work correctly.

For arduino/setup-task the newest tag was used as older ones appeared to be too old.