### PR TITLE
ci: Don't exec Windows Debug binaries

### DIFF
--- a/.github/CMakeUserPresets.json
+++ b/.github/CMakeUserPresets.json
@@ -59,12 +59,6 @@
       "configurePreset": "ci-msvc",
       "configuration": "Release",
       "inherits": ["output-on-failure"]
-    },
-    {
-      "name": "ci-debug-msvc",
-      "configurePreset": "ci-msvc",
-      "configuration": "Debug",
-      "inherits": ["output-on-failure"]
     }
   ],
   "workflowPresets": [
@@ -128,10 +122,6 @@
         },
         {
           "type": "build",
-          "name": "ci-debug-msvc"
-        },
-        {
-          "type": "test",
           "name": "ci-debug-msvc"
         }
       ]


### PR DESCRIPTION
Windows Debug binaries don't work reliably on CI machine. The aoc binary itself never does anything which is why its execution has been disabled already earlier. This commit disables also execution of unit test binaries as they also cause intermittent failures due to mysterious "timeout" error almost immediately after startup.

These may get re-enabled in the future when the underlying cause for this is sorted out.