### PR TITLE
ci: Remove check for github-actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,8 +18,6 @@ jobs:
     uses: ./.github/workflows/check-clang-format.yaml
   check-clang-tidy:
     uses: ./.github/workflows/check-clang-tidy.yaml
-  check-github-actions:
-    uses: nikobockerman/github-workflows/.github/workflows/check-github-actions.yaml@2cf25ef6b41c3eb97a1e61e328bdc34dc6c9b762
   check-prettier:
     uses: nikobockerman/github-workflows/.github/workflows/check-prettier.yaml@2cf25ef6b41c3eb97a1e61e328bdc34dc6c9b762
   check-renovate-config:
@@ -34,7 +32,6 @@ jobs:
       - build-test-run
       - check-clang-format
       - check-clang-tidy
-      - check-github-actions
       - check-prettier
       - check-renovate-config
       - check-shellcheck

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "scripts": {
-    "check:github-actions": "git ls-files '.github/**.yaml' | xargs -t -I {} action-validator {}",
     "check:yarn:dedupe": "yarn dedupe --check",
     "check:prettier": "prettier --check .",
     "check:renovateconfig": "npx --package=renovate --yes -- renovate-config-validator --strict",
@@ -12,8 +11,6 @@
     "node": "^22.0.0"
   },
   "devDependencies": {
-    "@action-validator/cli": "0.6.0",
-    "@action-validator/core": "0.6.0",
     "prettier": "3.6.2"
   }
 }

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -7,12 +7,6 @@ tasks:
     cmds:
       - clang-format -n -Werror --verbose $(git ls-files | grep -E
         '\.hpp$|\.cpp$')
-  check:github-actions:
-    desc: "Check - Github actions"
-    cmds:
-      - yarn run check:github-actions
-    deps:
-      - install:yarn
   check:prettier:
     desc: "Check - prettier"
     cmds:
@@ -37,7 +31,6 @@ tasks:
     desc: "All checks"
     deps:
       - check:clang-format
-      - check:github-actions
       - check:prettier
       - check:renovateconfig
       - check:shellcheck

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,33 +5,6 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@action-validator/cli@npm:0.6.0":
-  version: 0.6.0
-  resolution: "@action-validator/cli@npm:0.6.0"
-  dependencies:
-    chalk: "npm:5.2.0"
-  peerDependencies:
-    "@action-validator/core": 0.6.0
-  bin:
-    action-validator: cli.mjs
-  checksum: 10c0/78d8bec3fc8a12463e2f17d93e211b2800ac8b289a996aac6116d0827db18d4b2b0bbc651aada1de53eb0a526d2c034e1151bea843b6f11b0d0b54247494c5a6
-  languageName: node
-  linkType: hard
-
-"@action-validator/core@npm:0.6.0":
-  version: 0.6.0
-  resolution: "@action-validator/core@npm:0.6.0"
-  checksum: 10c0/026967e1c3bda47b67c06f976ff427e57ec266f8b32ee2e99c8b7d1ac73fb11082622a7c2010544a220f47f4724a265ff6db4069b18cb78cce58f1e717694977
-  languageName: node
-  linkType: hard
-
-"chalk@npm:5.2.0":
-  version: 5.2.0
-  resolution: "chalk@npm:5.2.0"
-  checksum: 10c0/8a519b35c239f96e041b7f1ed8fdd79d3ca2332a8366cb957378b8a1b8a4cdfb740d19628e8bf74654d4c0917aa10cf39c20752e177a1304eac29a1168a740e9
-  languageName: node
-  linkType: hard
-
 "prettier@npm:3.6.2":
   version: 3.6.2
   resolution: "prettier@npm:3.6.2"
@@ -45,8 +18,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@action-validator/cli": "npm:0.6.0"
-    "@action-validator/core": "npm:0.6.0"
     prettier: "npm:3.6.2"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
The tool used for that check doesn't support the full schema of what github action and workflow yamls can contain. Notably, path globs are not supported very well. In addition the tool doesn't seem to be maintained very actively.

Now that the PR required checks are not going to allow merging if Github refuses to parse the workflow files, let's rely on Github validating and showing errors in these files. Previously when the required check was based on poseidon/wait-for-status-checks action, that would had been a problem as parse error caused job not to start and that action ended up giving green light for merging.